### PR TITLE
-rオプションの実装

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -8,12 +8,15 @@ COLUMN_COUNT = 3
 
 def main
   is_option_all = false
+  is_reverse = false
 
   opt = OptionParser.new
   opt.on('-a') { is_option_all = true }
+  opt.on('-r') { is_reverse = true }
   opt.parse!(ARGV)
 
   file_names = is_option_all ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+  file_names.reverse! if is_reverse
 
   max_name_length = file_names.max_by(&:length).length
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -16,13 +16,13 @@ def main
   opt.parse!(ARGV)
 
   file_names = is_option_all ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
-  file_names.reverse! if is_reverse
+  sorted_file_names = is_reverse ? file_names.reverse : file_names
 
-  max_name_length = file_names.max_by(&:length).length
+  max_name_length = sorted_file_names.max_by(&:length).length
 
   rows = generate_rows(
-    ljust_dir_items(max_name_length, file_names),
-    calc_row_count(file_names.size)
+    ljust_dir_items(max_name_length, sorted_file_names),
+    calc_row_count(sorted_file_names.size)
   )
 
   rows.each { |row| puts row.join }


### PR DESCRIPTION
実装しましたのレビューをお願いします！
また、懸念点が1点あるのでご確認をお願いいたします。

### 懸念点
並べ替え処理に破壊的な変更を採用したのですが、やはり好ましくないでしょうか？
破壊的ではない並べ替えでは以下のような処理になるかと思います。
その際、`{ 表示項目変数 }` に対しどのような命名をするべきか全くイメージできず、破壊的な変更を採用いたしました。
- reverse_file_name だと、-rオプションが指定されない場合に不適切となる。
- -rオプションが指定されないときはそのままfile_namesを返すため、同じものが異なる変数名に格納されることに違和感がある

```ruby
is_option_all = false
is_reverse = false

opt = OptionParser.new
opt.on('-a') { is_option_all = true }
opt.on('-r') { is_reverse = true }
opt.parse!(ARGV)

file_names = is_option_all ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
{ 表示項目変数 } =  is_reverse ? file_names.reverse : file_names
```