### PR TITLE
ls -lコマンドの新規作成

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -69,11 +69,9 @@ def show_file_details(file_names)
 end
 
 def calc_max_string_length(details, key)
-  value_strings = details.map do |detail|
+  details.map do |detail|
     detail[key].to_s
-  end
-
-  value_strings.max_by(&:length).length
+  end.max_by(&:length).length
 end
 
 def extract_details(file_names)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -2,39 +2,173 @@
 
 # frozen_string_literal: true
 
+require 'etc'
 require 'optparse'
 
 COLUMN_COUNT = 3
 
+FILE_TYPE = {
+  '1' => 'p',
+  '2' => 'c',
+  '4' => 'd',
+  '6' => 'b',
+  '10' => '-',
+  '12' => 'l',
+  '14' => 's'
+}.freeze
+
+FILE_PERMISSION = {
+  '0' => '---',
+  '1' => '--x',
+  '2' => '-w-',
+  '3' => '-wx',
+  '4' => 'r--',
+  '5' => 'r-x',
+  '6' => 'rw-',
+  '7' => 'rwx'
+}.freeze
+
 def main
   is_option_all = false
   is_reverse = false
+  is_detail = false
 
   opt = OptionParser.new
   opt.on('-a') { is_option_all = true }
   opt.on('-r') { is_reverse = true }
+  opt.on('-l') { is_detail = true }
   opt.parse!(ARGV)
 
   file_names = is_option_all ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
   sorted_file_names = is_reverse ? file_names.reverse : file_names
 
-  max_name_length = sorted_file_names.max_by(&:length).length
+  if is_detail
+    show_file_details(sorted_file_names)
+  else
+    show_file_names(sorted_file_names)
+  end
+end
+
+def show_file_details(file_name)
+  extracted_details = extract_detail(generate_details, file_name)
+  formed_details = form_details(extracted_details)
+
+  puts "total #{formed_details['blocks'].sum}"
+
+  formed_details['file_names'].each_with_index do |_, index|
+    show_item = []
+    show_item.push(formed_details['symbolic_modes'][index])
+    show_item.push(formed_details['hard_link_strings'][index])
+    show_item.push(formed_details['user_names'][index])
+    show_item.push(formed_details['group_names'][index])
+    show_item.push(formed_details['size_strings'][index])
+    show_item.push(formed_details['updated_times'][index])
+    show_item.push(formed_details['file_names'][index])
+
+    puts show_item.join(' ')
+  end
+end
+
+def generate_details
+  {
+    'blocks' => [],
+    'symbolic_modes' => [],
+    'hard_link_strings' => [],
+    'user_names' => [],
+    'group_names' => [],
+    'size_strings' => [],
+    'updated_times' => [],
+    'file_names' => []
+  }
+end
+
+def extract_detail(details, file_names)
+  file_names.map do |file_name|
+    file = File::Stat.new("./#{file_name}")
+
+    details['blocks'].push(file.blocks)
+    details['symbolic_modes'].push(file_symbolic_mode(file))
+    details['hard_link_strings'].push(file.nlink.to_s)
+    details['user_names'].push(file_user_name(file))
+    details['group_names'].push(file_group_name(file))
+    details['size_strings'].push(file.size.to_s)
+    details['updated_times'].push(format_file_time(file))
+    details['file_names'].push(file_name)
+  end
+
+  details
+end
+
+def form_details(details)
+  max_hard_link_string_length = details['hard_link_strings'].max_by(&:length).length
+  details['hard_link_strings'] = rjust_items(max_hard_link_string_length, details['hard_link_strings'])
+
+  max_user_name_length = details['user_names'].max_by(&:length).length
+  details['user_names'] = ljust_items(max_user_name_length, details['user_names'])
+
+  max_group_name_length = details['group_names'].max_by(&:length).length
+  details['group_names'] = ljust_items(max_group_name_length, details['group_names'])
+
+  max_sizes_length = details['size_strings'].max_by(&:length).length
+  details['size_strings'] = rjust_items(max_sizes_length, details['size_strings'])
+
+  details
+end
+
+def show_file_names(file_names)
+  max_name_length = file_names.max_by(&:length).length
 
   rows = generate_rows(
-    ljust_dir_items(max_name_length, sorted_file_names),
-    calc_row_count(sorted_file_names.size)
+    ljust_items(max_name_length, file_names),
+    calc_row_count(file_names.size)
   )
+  rows.each { |row| puts row.join(' ') }
+end
 
-  rows.each { |row| puts row.join }
+def convert_to_symbolic_type(file_octal_type)
+  FILE_TYPE[file_octal_type]
+end
+
+def convert_to_symbolic_permission(file_octal_permission)
+  FILE_PERMISSION[file_octal_permission]
+end
+
+def file_symbolic_mode(file)
+  octal_mode = file.mode.to_s(8)
+
+  symbolic_type = convert_to_symbolic_type(octal_mode[0..-5])
+  symbolic_permissions = octal_mode[-3..].chars.map do |octal_permission|
+    convert_to_symbolic_permission(octal_permission)
+  end
+
+  symbolic_type + symbolic_permissions.join('')
+end
+
+def file_user_name(file)
+  Etc.getpwuid(file.uid).name
+end
+
+def file_group_name(file)
+  Etc.getgrgid(file.gid).name
+end
+
+def format_file_time(file)
+  file.mtime.strftime('%b %d %R')
 end
 
 def calc_row_count(dir_items_count)
   (dir_items_count / COLUMN_COUNT.to_f).ceil
 end
 
-def ljust_dir_items(max_name_length, dir_items)
+def ljust_items(max_name_length, dir_items)
   dir_items.map do |dir_item|
-    dir_item.ljust(max_name_length + 1)
+    dir_item.ljust(max_name_length)
+  end
+end
+
+def rjust_items(max_name_length, dir_items)
+  dir_items.map do |dir_item|
+    dir_item.rjust(max_name_length)
   end
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -29,17 +29,17 @@ FILE_PERMISSION = {
 }.freeze
 
 def main
-  is_option_all = false
+  is_all = false
   is_reverse = false
   is_detail = false
 
   opt = OptionParser.new
-  opt.on('-a') { is_option_all = true }
+  opt.on('-a') { is_all = true }
   opt.on('-r') { is_reverse = true }
   opt.on('-l') { is_detail = true }
   opt.parse!(ARGV)
 
-  file_names = is_option_all ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+  file_names = is_all ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
   sorted_file_names = is_reverse ? file_names.reverse : file_names
 
   if is_detail
@@ -69,21 +69,18 @@ def show_file_details(file_names)
 end
 
 def calc_max_string_length(details, key)
-  max_length = 0
-  details.each do |detail|
-    length = detail[key].is_a?(String) ? detail[key].length : detail[key].to_s.length
-    max_length = length > max_length ? length : max_length
+  value_strings = details.map do |detail|
+    detail[key].to_s
   end
 
-  max_length
+  value_strings.max_by(&:length).length
 end
 
 def extract_details(file_names)
-  details = []
   file_names.map do |file_name|
     file = File::Stat.new("./#{file_name}")
 
-    details << {
+    {
       blocks: file.blocks,
       symbolic_mode: file_symbolic_mode(file),
       hard_link: file.nlink,
@@ -94,8 +91,6 @@ def extract_details(file_names)
       file_name: file_name
     }
   end
-
-  details
 end
 
 def file_symbolic_mode(file)
@@ -106,7 +101,7 @@ def file_symbolic_mode(file)
     FILE_PERMISSION[octal_permission]
   end
 
-  symbolic_type + symbolic_permissions.join('')
+  symbolic_type + symbolic_permissions.join
 end
 
 def file_user_name(file)


### PR DESCRIPTION
実装が完了しましたので、ご確認をお願いします！
チケットと同様の内容をこちらにも追記します。

- 表示項目を整形するためにコードが膨らんだ
    - 項目によって右寄せ・左寄せなどする必要があり、処理を統一できなかった
- 「詳細」という塊で扱おうとした結果、破壊的な変更になってしまった
- ファイルに割り当てられるブロック数が合わない
    - `ls -s`
        - 割り当てられるブロック数が4
    - `file = File::Stat.new`で生成した後に`file.blocks`
        - 割り当てられるブロック数が8